### PR TITLE
더미 데이터 활용하여 검색 페이지 작업

### DIFF
--- a/src/components/CategoryButton.tsx
+++ b/src/components/CategoryButton.tsx
@@ -1,0 +1,23 @@
+import clsx from 'clsx';
+
+interface CategoryButtonProps {
+  category: string;
+  onClick: () => void;
+  isActive?: boolean;
+}
+
+const CategoryButton = ({ category, onClick, isActive = false }: CategoryButtonProps) => {
+  return (
+    <button
+      onClick={onClick}
+      className={clsx(
+        'rounded-full px-2 py-1 text-sm',
+        isActive ? 'bg-gray-900 text-white' : 'bg-gray-100 text-black hover:bg-gray-200'
+      )}
+    >
+      {category}
+    </button>
+  );
+};
+
+export default CategoryButton;

--- a/src/components/GroupSummary.tsx
+++ b/src/components/GroupSummary.tsx
@@ -1,0 +1,37 @@
+import { Meeting } from '../models/meeting.model';
+import { Link } from 'react-router';
+import { LuCalendar, LuUser } from 'react-icons/lu';
+
+interface MeetingSummaryProps {
+  meeting: Meeting;
+}
+
+const GroupSummary = ({ meeting }: MeetingSummaryProps) => {
+  return (
+    <Link to={`/groups/${meeting.id}`} className="flex items-center gap-4">
+      <div>
+        <div className="size-20 rounded-xl bg-gray-200 transition-all md:size-24 md:rounded-2xl" />
+        {/* <img src={meeting.imgUrl} alt={meeting.title} /> */}
+      </div>
+      <div className="flex h-full flex-col gap-2">
+        <h3 className="font-semibold md:text-xl">{meeting.title}</h3>
+        <p className="md:text-md text-sm font-thin lg:text-base">{meeting.description}</p>
+        <div className="flex items-center justify-center text-sm font-thin">
+          <span className="flex items-center text-gray-500">
+            <LuCalendar />
+            {meeting.created_at.toLocaleDateString()}
+          </span>
+          <span> • </span>
+          <span className="flex items-center">
+            <LuUser />
+            {15}
+          </span>
+          <span> • </span>
+          <span>{meeting.topic}</span>
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+export default GroupSummary;

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { LuSearch } from 'react-icons/lu';
 import { cn } from '../utils/utils';
+import { useNavigate, useSearchParams, useLocation } from 'react-router-dom';
 
 interface SearchInputProps {
   className?: string;
@@ -10,12 +10,25 @@ interface SearchInputProps {
 const SearchInput = ({ className }: SearchInputProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
+  const location = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const handleKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter' && inputRef.current) {
       const keyword = inputRef.current.value;
-      navigate(`/search?keyword=${keyword}`);
-      return;
+
+      if (keyword) {
+        const newSearchParams = new URLSearchParams(searchParams);
+        newSearchParams.set('keyword', keyword);
+
+        if (location.pathname === '/') {
+          newSearchParams.set('category', '전체');
+          newSearchParams.set('sort', 'recommend');
+          navigate(`/search?${newSearchParams.toString()}`);
+        } else {
+          setSearchParams(newSearchParams);
+        }
+      }
     }
   };
 

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,8 +1,7 @@
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import clsx from 'clsx';
 import { LuAlignJustify } from 'react-icons/lu';
 import { useState, useEffect, useRef } from 'react';
-import { useUserStore } from '../../zustand/store';
 import UserHeaderForm from '../user/UserHeaderForm';
 
 const CATEGORY_LIST = [
@@ -13,7 +12,6 @@ const CATEGORY_LIST = [
 
 const Header = () => {
   const location = useLocation();
-  const navigate = useNavigate();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -6,7 +6,9 @@ const Layout = () => {
   return (
     <div className="mx-auto flex min-h-screen flex-col lg:max-w-6xl">
       <Header />
-      <Outlet />
+      <main className="p-4">
+        <Outlet />
+      </main>
     </div>
   );
 };

--- a/src/components/search/GroupSearchFilter.tsx
+++ b/src/components/search/GroupSearchFilter.tsx
@@ -1,0 +1,76 @@
+import CategoryButton from '../CategoryButton';
+import { useSearchParams } from 'react-router';
+import { useEffect } from 'react';
+
+const CATEGORY_LIST = [
+  '전체',
+  '운동',
+  '자기계발',
+  '동네친구',
+  '아웃도어/여행',
+  '가족/육아',
+  '반려동물',
+  '음식/음료',
+  '취미/오락',
+  '독서/인문학',
+  '문화/예술',
+  '음악/악기',
+  '기타',
+];
+
+const SortList = [
+  { value: 'recommend', label: '추천순' },
+  { value: 'recent', label: '신규순' },
+];
+
+const GroupSearchFilter = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  useEffect(() => {
+    if (!searchParams.get('category')) {
+      setSearchParams({ category: '전체', sort: 'recommend' });
+    }
+  }, [searchParams, setSearchParams]);
+
+  return (
+    <div>
+      <div className="mb-4">
+        <h2 className="mb-2 text-xl font-bold">카테고리</h2>
+        <div className="flex flex-wrap gap-2">
+          {CATEGORY_LIST.map((category) => (
+            <CategoryButton
+              key={category}
+              category={category}
+              onClick={() => {
+                const newSearchParams = new URLSearchParams(searchParams);
+                newSearchParams.set('category', category);
+                setSearchParams(newSearchParams);
+              }}
+              isActive={category === searchParams.get('category')}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <h2 className="mb-2 text-xl font-bold">정렬</h2>
+        <div className="flex gap-4">
+          {SortList.map((sort) => (
+            <CategoryButton
+              key={sort.value}
+              category={sort.label}
+              onClick={() => {
+                const newSearchParams = new URLSearchParams(searchParams);
+                newSearchParams.set('sort', sort.value);
+                setSearchParams(newSearchParams);
+              }}
+              isActive={sort.value === searchParams.get('sort')}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GroupSearchFilter;

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,5 +1,5 @@
 import { Meeting, MeetingDetail } from '../models/meeting.model';
-import { Topic } from '../models/topic.model';
+import { Category as Topic } from '../models/category.model';
 import { Gender, User } from '../models/user.model';
 import { Posting, PostingDetail } from '../models/posting.model';
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter, Routes, Route } from 'react-router';
 import Layout from './components/common/Layout.tsx';
 import Home from './pages/Home.tsx';
 import Search from './pages/Search.tsx';
+import Signup from './pages/Signup.tsx';
 import Login from './pages/Login.tsx';
 import Profile from './pages/Profile.tsx';
 import GroupMain from './pages/GroupMain.tsx';
@@ -14,7 +15,6 @@ import GroupCreate from './pages/GroupCreate.tsx';
 import PostList from './pages/PostList.tsx';
 import PostDetail from './pages/PostDetail.tsx';
 import PostWrite from './pages/PostWrite.tsx';
-import Signup from './pages/SignUp.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/models/category.model.ts
+++ b/src/models/category.model.ts
@@ -1,4 +1,4 @@
-export enum Topic {
+export enum Category {
   운동 = '운동',
   자기계발 = '자기계발',
   동네친구 = '동네친구',

--- a/src/models/meeting.model.ts
+++ b/src/models/meeting.model.ts
@@ -1,4 +1,4 @@
-import { Topic } from './topic.model';
+import { Category } from './category.model';
 import { User } from './user.model';
 
 export interface Meeting {
@@ -13,7 +13,7 @@ export interface Meeting {
   age_condition: string;
   owner_user_id: number;
   created_at: Date;
-  topic: Topic;
+  topic: Category;
 }
 
 export interface MeetingDetail extends Meeting {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,10 @@
+import SearchInput from '../components/SearchInput';
+
 const Home = () => {
   return (
     <div>
-      <h1>Home</h1>
+      {/*검색창 컴포넌트 : 검색어 입력시 검색페이지로 이동 */}
+      <SearchInput />
     </div>
   );
 };

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,7 +1,21 @@
+import SearchInput from '../components/SearchInput';
+import { useSearchParams } from 'react-router';
+import { dummyMeetings } from '../data';
+import GroupSummary from '../components/GroupSummary';
+import GroupSearchFilter from '../components/search/GroupSearchFilter';
+
 const Search = () => {
+  const [searchParams] = useSearchParams();
+  console.log(searchParams.get('keyword'));
   return (
-    <div>
-      <h1>Search</h1>
+    <div className="flex flex-col gap-4">
+      <SearchInput />
+      <GroupSearchFilter />
+      <div className="flex flex-col gap-3 md:gap-5">
+        {dummyMeetings.map((meeting) => (
+          <GroupSummary key={meeting.id} meeting={meeting} />
+        ))}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
# 🔍 PR 개요

검색 페이지에서 그룹 보기 

## 📝 작업 내용

<!-- 구현한 기능에 대해 자세히 작성해주세요 -->

- [x] 검색 페이지에서 그룹 보기 레이아웃 (모바일, 태블릿) (데스크탑은 X)
- [x] 카테고리 선택, 정렬 선택 기능 (선택에 따른 실제 필터링과 정렬은 아직 X )
- [x] 홈 페이지에 검색 컴포넌트 기능

## 📸 스크린샷

<img width="480" alt="스크린샷 2024-12-12 오후 3 52 58" src="https://github.com/user-attachments/assets/9a91b51f-7f04-4936-a3ef-ea20b396c37a" />


## 🧪 체크리스트

- [x] 수동 테스트 완료
- [ ] 불필요한 코드 없음 (console.log, 주석 등)
- [ ] 명확한 커밋 메세지
- [ ] 충분한 문서화



