### PR TITLE
서치페이지 무한스크롤과 홈화면에 토픽별 미팅 조회 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@tanstack/react-query": "^5.62.8",
         "axios": "^1.7.9",
         "clsx": "^2.1.1",
+        "embla-carousel-autoplay": "^8.5.1",
+        "embla-carousel-react": "^8.5.1",
         "firebase": "^11.0.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -3804,6 +3806,43 @@
       "integrity": "sha512-ZpSAUOZ2Izby7qnZluSrAlGgGQzucmFbN0n64dYzocYxnxV5ufurpj3VgEe4cUp7ir9LmeLxNYo8bVnlM8bQHw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.5.1.tgz",
+      "integrity": "sha512-JUb5+FOHobSiWQ2EJNaueCNT/cQU9L6XWBbWmorWPQT9bkbk+fhsuLr8wWrzXKagO3oWszBO7MSx+GfaRk4E6A==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-autoplay": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.5.1.tgz",
+      "integrity": "sha512-FnZklFpePfp8wbj177UwVaGFehgs+ASVcJvYLWTtHuYKURynCc3IdDn2qrn0E5Qpa3g9yeGwCS4p8QkrZmO8xg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.5.1"
+      }
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.5.1.tgz",
+      "integrity": "sha512-z9Y0K84BJvhChXgqn2CFYbfEi6AwEr+FFVVKm/MqbTQ2zIzO1VQri6w67LcfpVF0AjbhwVMywDZqY4alYkjW5w==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.5.1",
+        "embla-carousel-reactive-utils": "8.5.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.5.1.tgz",
+      "integrity": "sha512-n7VSoGIiiDIc4MfXF3ZRTO59KDp820QDuyBDGlt5/65+lumPHxX2JLz0EZ23hZ4eg4vZGUXwMkYv02fw2JVo/A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.5.1"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hookform/resolvers": "^3.9.1",
         "@mui/material": "^6.1.10",
+        "@tanstack/react-query": "^5.62.8",
         "axios": "^1.7.9",
         "clsx": "^2.1.1",
         "firebase": "^11.0.2",
@@ -2567,6 +2568,32 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.62.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.62.8.tgz",
+      "integrity": "sha512-4fV31vDsUyvNGrKIOUNPrZztoyL187bThnoQOvAXEVlZbSiuPONpfx53634MKKdvsDir5NyOGm80ShFaoHS/mw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.62.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.62.8.tgz",
+      "integrity": "sha512-8TUstKxF/fysHonZsWg/hnlDVgasTdHx6Q+f1/s/oPKJBJbKUWPZEHwLTMOZgrZuroLMiqYKJ9w69Abm8mWP0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.62.8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@tanstack/react-query": "^5.62.8",
     "axios": "^1.7.9",
     "clsx": "^2.1.1",
+    "embla-carousel-autoplay": "^8.5.1",
+    "embla-carousel-react": "^8.5.1",
     "firebase": "^11.0.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
     "@mui/material": "^6.1.10",
+    "@tanstack/react-query": "^5.62.8",
     "axios": "^1.7.9",
     "clsx": "^2.1.1",
     "firebase": "^11.0.2",

--- a/src/api/meetings.api.ts
+++ b/src/api/meetings.api.ts
@@ -3,7 +3,7 @@ import { Topic } from '../models/topic.model';
 import { Meeting, MeetingDetail } from '../models/meeting.model';
 import { requestHandler } from './http';
 
-interface MeetingResponse {
+export interface MeetingResponse {
   meeting: Meeting[];
   total: number;
   currentPage: number;

--- a/src/components/TopicCarousel.tsx
+++ b/src/components/TopicCarousel.tsx
@@ -13,6 +13,7 @@ const TopicCarousel = () => {
     }
   }, [emblaApi]);
 
+  // TODO: 보이는 캐러샐의 데이터만 불러오는 등의 최적화가 필요합니다.
   return (
     <div className="overflow-hidden" ref={emblaRef}>
       <div className="flex">

--- a/src/components/TopicCarousel.tsx
+++ b/src/components/TopicCarousel.tsx
@@ -1,0 +1,27 @@
+import useEmblaCarousel from 'embla-carousel-react';
+import { useEffect } from 'react';
+import Autoplay from 'embla-carousel-autoplay';
+import useTopics from '../hooks/useTopics';
+import TopicCarouselItem from './TopicCarouselItem';
+const TopicCarousel = () => {
+  const [emblaRef, emblaApi] = useEmblaCarousel({ loop: false }, [Autoplay()]);
+  const { topics } = useTopics();
+
+  useEffect(() => {
+    if (emblaApi) {
+      console.log(emblaApi.slideNodes());
+    }
+  }, [emblaApi]);
+
+  return (
+    <div className="overflow-hidden" ref={emblaRef}>
+      <div className="flex">
+        {topics.map((topic) => (
+          <TopicCarouselItem key={topic.id} topic={topic} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default TopicCarousel;

--- a/src/components/TopicCarousel.tsx
+++ b/src/components/TopicCarousel.tsx
@@ -4,7 +4,12 @@ import Autoplay from 'embla-carousel-autoplay';
 import useTopics from '../hooks/useTopics';
 import TopicCarouselItem from './TopicCarouselItem';
 const TopicCarousel = () => {
-  const [emblaRef, emblaApi] = useEmblaCarousel({ loop: false }, [Autoplay()]);
+  const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true }, [
+    Autoplay({
+      delay: 6000,
+      stopOnMouseEnter: true,
+    }),
+  ]);
   const { topics } = useTopics();
 
   useEffect(() => {

--- a/src/components/TopicCarouselItem.tsx
+++ b/src/components/TopicCarouselItem.tsx
@@ -1,0 +1,39 @@
+import { Topic } from '../models/topic.model';
+import { getMeetings } from '../api/meetings.api';
+import { useState, useEffect } from 'react';
+import { Meeting } from '../models/meeting.model';
+import GroupSummary from './GroupSummary';
+
+const TopicCarouselItem = ({ topic }: { topic: Topic }) => {
+  const [meetings, setMeetings] = useState<Meeting[]>([]);
+
+  useEffect(() => {
+    const fetchMeetings = async () => {
+      try {
+        const response = await getMeetings({ page: 1, topic_id: topic.id });
+        setMeetings(response.meeting);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchMeetings();
+  }, []);
+  return (
+    <div
+      className="flex min-w-0 flex-col gap-4"
+      style={{
+        flex: '0 0 100%',
+      }}
+    >
+      <h2>{topic.name}</h2>
+      <div className="flex flex-col gap-4">
+        {meetings.map((meeting) => (
+          <GroupSummary key={meeting.id} meeting={meeting} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default TopicCarouselItem;

--- a/src/hooks/useMeetingsInfinite.ts
+++ b/src/hooks/useMeetingsInfinite.ts
@@ -1,0 +1,47 @@
+import { getMeetings, getMeetingsParams, MeetingResponse } from '../api/meetings.api';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useSearchParams } from 'react-router';
+import { useEffect } from 'react';
+
+const useMeetingsInfinite = () => {
+  const [searchParams] = useSearchParams();
+
+  const fetchMeetings = async ({
+    pageParam = 1,
+  }: {
+    pageParam?: number;
+  }): Promise<MeetingResponse> => {
+    const keyword = searchParams.get('keyword') || undefined;
+    const topicId = searchParams.get('topic');
+    const params: getMeetingsParams = { page: pageParam };
+
+    if (keyword) {
+      params.keyword = keyword;
+    }
+
+    if (topicId) {
+      params.topic_id = parseInt(topicId, 10);
+    }
+
+    return await getMeetings(params);
+  };
+
+  const { data, isFetching, hasNextPage, fetchNextPage, isFetchingNextPage, refetch } =
+    useInfiniteQuery({
+      queryKey: ['meetings', searchParams.toString()],
+      queryFn: fetchMeetings,
+      getNextPageParam: (lastPage) => {
+        const isLastPage = Math.ceil(lastPage.total / 10) === lastPage.currentPage;
+        return isLastPage ? null : lastPage.currentPage + 1;
+      },
+      initialPageParam: 1,
+    });
+
+  useEffect(() => {
+    refetch();
+  }, [searchParams, refetch]);
+
+  return { data, isFetching, hasNextPage, fetchNextPage, isFetchingNextPage };
+};
+
+export default useMeetingsInfinite;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,38 +22,43 @@ import UserModify from './pages/UserModify.tsx';
 import ProfileLayout from './components/user/\bProfileMenu/ProfileLayout.tsx';
 import ResetPw from './pages/ResetPw.tsx';
 import WithdrawUser from './pages/WithdrawUser.tsx';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Layout />}>
-          <Route index element={<Home />} />
-          <Route path="/search" element={<Search />} />
-          {/* 유저관련 */}
-          <Route path="/signup" element={<Signup />} />
-          <Route path="/login" element={<Login />} />
-          <Route path="/users/:user_id" element={<ProfileLayout />}>
-            <Route index element={<Profile />} />
-            <Route path="modify" element={<UserModify />} />
-            <Route path="manage" element={<GroupManageList />} />
-            <Route path="logout" element={<Logout />} />
-            <Route path="reset-password" element={<ResetPw />} />
-            <Route path="withdraw" element={<WithdrawUser />} />
-          </Route>
-          {/* 그룹관련 */}
-          <Route path="/groups/:group_id" element={<GroupLayout />}>
-            <Route index element={<GroupMain />} />
-            <Route path="members" element={<GroupMembers />} />
-            <Route path="posts" element={<PostList />} />
-            <Route path="posts/write" element={<PostWrite />} />
-            <Route path="posts/:post_id" element={<PostDetail />} />
-            <Route path="manage" element={<GroupManage />} />
-          </Route>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Layout />}>
+            <Route index element={<Home />} />
+            <Route path="/search" element={<Search />} />
+            {/* 유저관련 */}
+            <Route path="/signup" element={<Signup />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/users/:user_id" element={<ProfileLayout />}>
+              <Route index element={<Profile />} />
+              <Route path="modify" element={<UserModify />} />
+              <Route path="manage" element={<GroupManageList />} />
+              <Route path="logout" element={<Logout />} />
+              <Route path="reset-password" element={<ResetPw />} />
+              <Route path="withdraw" element={<WithdrawUser />} />
+            </Route>
+            {/* 그룹관련 */}
+            <Route path="/groups/:group_id" element={<GroupLayout />}>
+              <Route index element={<GroupMain />} />
+              <Route path="members" element={<GroupMembers />} />
+              <Route path="posts" element={<PostList />} />
+              <Route path="posts/write" element={<PostWrite />} />
+              <Route path="posts/:post_id" element={<PostDetail />} />
+              <Route path="manage" element={<GroupManage />} />
+            </Route>
 
-          <Route path="/groups/create" element={<GroupCreate />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+            <Route path="/groups/create" element={<GroupCreate />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </QueryClientProvider>
   </StrictMode>
 );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,10 +1,13 @@
 import SearchInput from '../components/SearchInput';
+import TopicCarousel from '../components/TopicCarousel';
 
 const Home = () => {
   return (
-    <div>
+    <div className="flex flex-col gap-4">
       {/*검색창 컴포넌트 : 검색어 입력시 검색페이지로 이동 */}
       <SearchInput />
+      {/*TopicCarousel 컴포넌트 : 토픽별 캐러셀 */}
+      <TopicCarousel />
     </div>
   );
 };


### PR DESCRIPTION
# 🔍 PR 개요

서치페이지 무한스크롤과 홈화면에 토픽별 미팅 조회 기능 추가

## 📝 작업 내용

<!-- 구현한 기능에 대해 자세히 작성해주세요 -->

- [ ] 서치페이지 무한스크롤
- [ ] 홈화면에 토픽별 미팅 조회 기능 추가

## 🔗 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->

- Closes #이슈번호
- Related to #이슈번호

## 📸 스크린샷


## 🧪 체크리스트

<!-- 테스트 항목을 체크해주세요 -->

- [ ] 수동 테스트 완료
- [ ] 불필요한 코드 없음 (console.log, 주석 등)
- [ ] 명확한 커밋 메세지
- [ ] 충분한 문서화

## 🔄 변경 로직 설명

<!-- 주요 로직 변경사항을 설명해주세요 -->

```js
// 예시 코드나 설명
```

## 추후에 작업할 사항

- [ ] 로딩중, 실패시 UI 추가
- [ ] 토픽별 조회 최적화
